### PR TITLE
Update Fieldmaps for Returns

### DIFF
--- a/atd_knack_api/_fieldmaps.py
+++ b/atd_knack_api/_fieldmaps.py
@@ -37,8 +37,8 @@ so:
             - default : used to set the default value. required if no field `id` is present.
                 ie, this value is set on the destination payload when no src data is 
                 provided. it is defined on the `dest` application field definition.
-
 """
+
 FIELDMAP = {
     "inventory_item": {
         "comment": "Translates between work order records (data tracker) and inventory requests (finance system).",
@@ -195,7 +195,7 @@ FIELDMAP = {
                 },
             },
             {
-                "comment": "Account ID of the data tracker user to which the item has been issued.",
+                "comment": "Account ID of the data tracker user to whom the item has been issued or returned by.",
                 "directions": ["to_data_tracker"],
                 "apps": {
                     "finance_system": {"id": "field_792"},

--- a/atd_knack_api/_fieldmaps.py
+++ b/atd_knack_api/_fieldmaps.py
@@ -251,10 +251,26 @@ FIELDMAP = {
             },
             {
                 "comment": "The transaction type (work order, return, etc)",
-                "directions": ["to_finance_system"],
+                "directions": ["to_finance_system", "to_data_tracker"],
                 "apps": {
                     "finance_system": {"id": "field_509"},
                     "data_tracker": {"id": "field_769"},
+                },
+            },
+            {
+                "comment": "The status of any return request.",
+                "directions": ["to_finance_system", "to_data_tracker"],
+                "apps": {
+                    "finance_system": {"id": "field_813"},
+                    "data_tracker": {"id": "field_3510"},
+                },
+            },
+            {
+                "comment": "The quantity of any return request.",
+                "directions": ["to_finance_system", "to_data_tracker"],
+                "apps": {
+                    "finance_system": {"id": "field_513"},
+                    "data_tracker": {"id": "field_3509"},
                 },
             },
             {

--- a/atd_knack_api/_fieldmaps.py
+++ b/atd_knack_api/_fieldmaps.py
@@ -218,6 +218,16 @@ FIELDMAP = {
                 },
             },
             {
+                "comment": "Knack record ID of the related work order in the Data Tracker",
+                "directions": [
+                    "to_data_tracker",
+                ],
+                "apps": {
+                    "finance_system": {"id": "field_816"},
+                    "data_tracker": {"id": "field_514", "transform" : "text_to_connection"},
+                },
+            },
+            {
                 "comment": "item quantity",
                 "directions": ["to_finance_system", "to_data_tracker"],
                 "apps": {
@@ -306,7 +316,7 @@ FIELDMAP = {
             },
             {
                 "comment": "If the txn record has been sent to the Finance System.",
-                "directions": ["to_data_tracker", "callback_data_tracker"],
+                "directions": ["callback_data_tracker"],
                 "apps": {
                     "finance_system": {"id": None},
                     "data_tracker": {"id": "field_3453", "default": True},
@@ -314,7 +324,7 @@ FIELDMAP = {
             },
             {
                 "comment": "If the txn record has been sent to the Data Tracker.",
-                "directions": ["to_data_tracker", "callback_finance_system"],
+                "directions": ["callback_finance_system"],
                 "apps": {
                     "finance_system": {"id": "field_789", "default": True},
                     "data_tracker": {"id": None},

--- a/atd_knack_api/_inventory.py
+++ b/atd_knack_api/_inventory.py
@@ -4,11 +4,11 @@ the Finance System.
 """
 import logging
 from pprint import pprint as print
-import pdb
 
 import knackpy
 import requests
 
+# import _setpath # uncomment this for local development
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api._models import Record
 from atd_knack_api.secrets import KNACK_CREDENTIALS
@@ -33,7 +33,6 @@ def handle_request(app_id_src, app_id_dest, data, record_type):
     record = Record(app_id_src, app_id_dest, data, record_type=record_type)
 
     res = record.send()
-
     """
     We flip src/dest here to "callback" to the src app with record values from the 
     created/updated record.
@@ -48,6 +47,7 @@ def handle_request(app_id_src, app_id_dest, data, record_type):
 
 
 def main(app_id_src, app_id_dest):
+
     app_name_src = KNACK_CREDENTIALS[app_id_src]["name"]
 
     record_type = "inventory_request"

--- a/atd_knack_api/_inventory.py
+++ b/atd_knack_api/_inventory.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)
 
     # test finance to data tracker
-    main("5b422c9b13774837e54ed814", "5815f29f7f7252cc2ca91c4f")
+    # main("5b422c9b13774837e54ed814", "5815f29f7f7252cc2ca91c4f")
 
     # test data tracker to finance
-    main("5815f29f7f7252cc2ca91c4f", "5b422c9b13774837e54ed814")
+    # main("5815f29f7f7252cc2ca91c4f", "5b422c9b13774837e54ed814")

--- a/atd_knack_api/_logging.py
+++ b/atd_knack_api/_logging.py
@@ -1,12 +1,19 @@
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 
 def get_logger(name):
     # init logger
     logger = logging.getLogger(name)
 
-    # log rotate based on filesize
-    file_handler = RotatingFileHandler(f"log/{name}.log", maxBytes=2000000)
+    
+    log_dest = "log"
+
+    if not os.path.exists(log_dest):
+        os.makedirs(log_dest)
+
+    # log rotate based on filesize        
+    file_handler = RotatingFileHandler(f"{log_dest}/{name}.log", maxBytes=2000000)
     
     # print timestamp in logfile
     formatter = logging.Formatter(

--- a/atd_knack_api/_models.py
+++ b/atd_knack_api/_models.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import knackpy
 
-# import _setpath # uncomment this for local development
+import _setpath  # uncomment this for local development
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api import _transforms
 from atd_knack_api.secrets import KNACK_CREDENTIALS
@@ -12,9 +12,7 @@ class Record(object):
     Transform a Knack record from a source application to a destination application.
     """
 
-    def __init__(
-        self, app_id_src, app_id_dest, data, record_type=None, callback=False
-    ):
+    def __init__(self, app_id_src, app_id_dest, data, record_type=None, callback=False):
 
         self.app_id_src = app_id_src
         self.app_id_dest = app_id_dest
@@ -83,7 +81,9 @@ class Record(object):
         """
 
         print("\n========== Record Data ==========")
-        print(f"src : {self.app_name_src}\ndest : {self.app_name_dest}")
+        print(
+            f"src : {self.app_name_src}\ndest : {self.app_name_dest}\ndirection : {self.direction}"
+        )
 
         for field in self.fields:
             d = OrderedDict({})
@@ -97,7 +97,7 @@ class Record(object):
             print(f"comment: {field.get('comment')}")
             print(f"src: {self.data.get(src_key)}")
             print(f"dest: {self.payload.get(dest_key)}")
-            print("*-------------------------*\n")
+            print("-------------------------")
 
         return
 

--- a/atd_knack_api/_models.py
+++ b/atd_knack_api/_models.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import knackpy
 
-import _setpath  # uncomment this for local development
+# import _setpath  # uncomment this for local development
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api import _transforms
 from atd_knack_api.secrets import KNACK_CREDENTIALS

--- a/atd_knack_api/_models.py
+++ b/atd_knack_api/_models.py
@@ -1,5 +1,7 @@
+from collections import OrderedDict
 import knackpy
 
+# import _setpath # uncomment this for local development
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api import _transforms
 from atd_knack_api.secrets import KNACK_CREDENTIALS
@@ -74,6 +76,30 @@ class Record(object):
             payload[dest_field_id] = val
 
         return payload
+
+    def debug(self):
+        """
+        Print a helpful comparison of the input data vs the output payload.
+        """
+
+        print("\n========== Record Data ==========")
+        print(f"src : {self.app_name_src}\ndest : {self.app_name_dest}")
+
+        for field in self.fields:
+            d = OrderedDict({})
+
+            if self.direction not in field["directions"]:
+                continue
+
+            src_key = field.get("apps").get(self.app_name_src).get("id")
+            dest_key = field.get("apps").get(self.app_name_dest).get("id")
+
+            print(f"comment: {field.get('comment')}")
+            print(f"src: {self.data.get(src_key)}")
+            print(f"dest: {self.payload.get(dest_key)}")
+            print("*-------------------------*\n")
+
+        return
 
     def _set_method(self):
         """

--- a/atd_knack_api/_setpath.py
+++ b/atd_knack_api/_setpath.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))

--- a/atd_knack_api/api.py
+++ b/atd_knack_api/api.py
@@ -7,6 +7,7 @@ import logging
 from flask import Flask, request, abort
 from flask_cors import CORS
 
+import _setpath
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api._logging import get_logger
 from atd_knack_api import _inventory

--- a/atd_knack_api/api.py
+++ b/atd_knack_api/api.py
@@ -7,7 +7,7 @@ import logging
 from flask import Flask, request, abort
 from flask_cors import CORS
 
-# import _setpath
+# import _setpath # uncomment this for local development
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api._logging import get_logger
 from atd_knack_api import _inventory

--- a/atd_knack_api/api.py
+++ b/atd_knack_api/api.py
@@ -7,7 +7,7 @@ import logging
 from flask import Flask, request, abort
 from flask_cors import CORS
 
-import _setpath
+# import _setpath
 from atd_knack_api._fieldmaps import FIELDMAP
 from atd_knack_api._logging import get_logger
 from atd_knack_api import _inventory


### PR DESCRIPTION
- Update fieldmaps for transaction returns
- Add a `Record.debug()` method which prints the `src` and `dest` values in the record payload side-by-side.
- Adds a `_setpath` script which can be turned on during local development